### PR TITLE
npm integration 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /.jsweet/
 /target/
 /src/main/resources/META-INF/resources/
+/dist/node

--- a/dist/README.md
+++ b/dist/README.md
@@ -1,0 +1,13 @@
+# JavaScipt part of j4ts candy
+
+## Common
+
+The package contains generated JavaScript code (bundle.js file) of
+[j4ts](https://github.com/j4ts/j4ts) project.
+It is translation of Java standard library  (JRE) to JavaScript.
+
+
+### Versioning
+
+Package has composite versioning. The part after dash represents
+original j4ts version.

--- a/dist/package.json
+++ b/dist/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "j4ts",
+  "version": "0.0.4-0.6.0",
+  "description": "JavaScript part of j4ts library",
+  "author": "Renaud Pawlak",
+  "contributors": [
+    {
+      "name": "Daneel Yaitskov",
+      "email": "dyaitskov@gmail.com",
+      "url": "https://yaitskov.blogspot.com/"
+    }
+  ],
+  "license": "Apache-2.0",
+  "files": [
+    "bundle.js"
+  ]
+}

--- a/pom.xml
+++ b/pom.xml
@@ -170,4 +170,62 @@
 		<url>http://www.jsweet.org</url>
 	</organization>
 
+	<profiles>
+		<profile>
+			<id>publish-npmjs</id>
+			<properties>
+				<node.version>v6.11.2</node.version>
+				<npm.version>3.10.10</npm.version>
+			</properties>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>com.github.eirslett</groupId>
+						<artifactId>frontend-maven-plugin</artifactId>
+						<version>1.3</version>
+						<executions>
+							<execution>
+								<id>install node and npm</id>
+								<goals>
+									<goal>install-node-and-npm</goal>
+								</goals>
+								<phase>install</phase>
+								<configuration>
+									<nodeVersion>${node.version}</nodeVersion>
+									<npmVersion>${npm.version}</npmVersion>
+								</configuration>
+							</execution>
+							<execution>
+								<id>npm version</id>
+								<goals>
+									<goal>npm</goal>
+								</goals>
+								<phase>install</phase>
+								<configuration>
+									<arguments>
+										version 0.0.4-${project.version}
+									</arguments>
+								</configuration>
+							</execution>
+							<execution>
+								<id>npm publish</id>
+								<goals>
+									<goal>npm</goal>
+								</goals>
+								<phase>install</phase>
+								<configuration>
+									<arguments>
+										publish
+									</arguments>
+								</configuration>
+							</execution>
+						</executions>
+						<configuration>
+							<workingDirectory>${project.basedir}/dist</workingDirectory>
+						</configuration>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
 </project>


### PR DESCRIPTION
Hi,

I am not a java script professional developer but even for me it looks ugly.
A framework generating java script code should talk to npm.
It is not convenient to extract java script files out of jars.

I check npmjs.com and there is no jsweet candies.

So I created a project java-jsweet there and [uploaded](https://www.npmjs.com/package/j4ts).
As me for permission if you need to publish update on your own.

In short npm for web developer is a super tool like maven for Java programmer.
Dependencies in JavaScript world are provided through npm.

I hope this contribution would help in gaining jsweet more popularity.

    