### PR TITLE
fix System.lineSeparator instead System.lineSeparatorâ€‹

### DIFF
--- a/src/main/java/java/lang/System.java
+++ b/src/main/java/java/lang/System.java
@@ -344,7 +344,7 @@ public final class System {
 		System.out = out;
 	}
 
-	public static String lineSeparator​() {
+	public static String lineSeparator() {
 		return getProperty("line.separator");
 	}
 


### PR DESCRIPTION
System.lineSeparator was committed with wrong character. It is visible on eclipse for windows.
