### PR TITLE
provide dedicated routines to handle codePoint{At,After,Before}(char[])

### DIFF
--- a/src/main/java/java/util/regex/Pattern.java
+++ b/src/main/java/java/util/regex/Pattern.java
@@ -103,7 +103,6 @@ public class Pattern implements Serializable {
 
         Supplier<def.js.String> mapper = Lang.<Supplier<def.js.String>> any((Function<def.js.String[], def.js.String>)
                 ((def.js.String ... args) -> {
-                    System.out.println("test");
                     if (!Array.isArray(args) || args[2] == undefined || args[2].length == 0) {
                         return args[1];
                     }


### PR DESCRIPTION
from the first commit:

> the java being replaced here works -- `new String(char[])` produces a string of those chars;
> but it transpiles in JS to `new String(string[])` which does not do the same thing,
> as JS uses the `toString` on the array and inserts a comma between all the characters.
> 
> (transpiling `new String(char[] a)` should trigger `new String(a?.join(''))` in TS;
> but that is a separate issue.)
> 
> this PR simply copies the code from string to chars with minor tweaks for code-point and length/end.
> 
> i'm not a unicode expert however so i'm not 100% sure of it, but it works for me in simple cases --
> whereas the old code only ever worked for strings of length <=1! (this is also skips the full-string-copy
> which will be much faster.)

the other is just a tiny clean up.

if you want the generated JS it's added in another branch -- https://github.com/ahgittin/j4ts/tree/fix-code-point-at-char-array-transpiled; feel free to take it.  (i wasn't sure if the etiquette is to rebuild it on every merge or just on release!)

